### PR TITLE
fix: use selected database in auth quickstart and env generation

### DIFF
--- a/src/__tests__/commands/auth.test.ts
+++ b/src/__tests__/commands/auth.test.ts
@@ -1,0 +1,127 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createAuthCommand } from '../../commands/auth';
+import { NileAPI } from '../../lib/api';
+import { ConfigManager } from '../../lib/config';
+import { GlobalOptions } from '../../lib/globalOptions';
+import { execSync } from 'child_process';
+
+jest.mock('../../lib/api');
+jest.mock('../../lib/config');
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}));
+
+describe('Auth Command', () => {
+  let mockNileAPI: jest.Mocked<any>;
+  let globalOptions: GlobalOptions;
+  let program: Command;
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => true);
+    jest.spyOn(console, 'error').mockImplementation(() => true);
+    jest.clearAllMocks();
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nile-auth-command-'));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+
+    globalOptions = {
+      workspace: 'test-workspace',
+      db: 'selected-db',
+      debug: false
+    };
+
+    mockNileAPI = {
+      createDatabaseCredentials: jest.fn().mockResolvedValue({
+        id: 'generated-user',
+        password: 'generated-secret'
+      }),
+      getDatabaseConnection: jest.fn().mockResolvedValue({
+        host: 'db.thenile.dev',
+        port: 5432,
+        database: 'selected-db',
+        user: 'postgres-user',
+        password: 'postgres-password'
+      })
+    };
+    (NileAPI as unknown as jest.Mock).mockImplementation(() => mockNileAPI);
+
+    (ConfigManager as unknown as jest.Mock).mockImplementation(() => ({
+      getWorkspace: jest.fn().mockReturnValue(globalOptions.workspace),
+      getDatabase: jest.fn().mockReturnValue(globalOptions.db),
+      getToken: jest.fn().mockReturnValue('test-token'),
+      getDbHost: jest.fn().mockReturnValue('db.thenile.dev'),
+      getGlobalHost: jest.fn().mockReturnValue('global.thenile.dev')
+    }));
+
+    program = new Command();
+    program.addCommand(createAuthCommand(() => globalOptions));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('uses the selected database for auth env and preserves unrelated env vars', async () => {
+    fs.writeFileSync('.env.local', 'EXISTING_KEY=keep-me\n');
+
+    await program.parseAsync(['node', 'test', 'auth', 'env', '--output', '.env.local']);
+
+    expect(mockNileAPI.createDatabaseCredentials).toHaveBeenCalledWith('test-workspace', 'selected-db');
+    expect(mockNileAPI.getDatabaseConnection).toHaveBeenCalledWith('test-workspace', 'selected-db');
+
+    const envContent = fs.readFileSync('.env.local', 'utf-8');
+    expect(envContent).toContain('EXISTING_KEY=keep-me');
+    expect(envContent).toContain('NILE_DATABASE_URL=postgres://postgres-user:postgres-password@db.thenile.dev:5432/selected-db');
+    expect(envContent).toContain('NILE_WORKSPACE=test-workspace');
+    expect(envContent).toContain('NILE_API_KEY=generated-user');
+    expect(envContent).toContain('NILE_API_SECRET=generated-secret');
+  });
+
+  it('quickstart uses the selected database and only wraps the layout once', async () => {
+    fs.writeFileSync('package.json', JSON.stringify({ name: 'demo-app' }, null, 2));
+    fs.mkdirSync(path.join('src', 'app'), { recursive: true });
+    fs.writeFileSync(
+      path.join('src', 'app', 'layout.tsx'),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`
+    );
+
+    await program.parseAsync(['node', 'test', 'auth', 'quickstart', '--nextjs']);
+
+    const firstLayout = fs.readFileSync(path.join('src', 'app', 'layout.tsx'), 'utf-8');
+    expect(firstLayout.match(/import \{ AuthProvider \} from '@\/components\/AuthProvider';/g)?.length).toBe(1);
+    expect(firstLayout.match(/<AuthProvider>/g)?.length).toBe(1);
+    expect(firstLayout.match(/<\/AuthProvider>/g)?.length).toBe(1);
+    expect(mockNileAPI.createDatabaseCredentials).toHaveBeenCalledWith('test-workspace', 'selected-db');
+    expect(mockNileAPI.getDatabaseConnection).toHaveBeenCalledWith('test-workspace', 'selected-db');
+    expect(execSync).toHaveBeenCalledWith('npm install @niledatabase/react @niledatabase/server', { stdio: 'inherit' });
+
+    program = new Command();
+    program.addCommand(createAuthCommand(() => globalOptions));
+    await program.parseAsync(['node', 'test', 'auth', 'quickstart', '--nextjs']);
+
+    const secondLayout = fs.readFileSync(path.join('src', 'app', 'layout.tsx'), 'utf-8');
+    expect(secondLayout.match(/import \{ AuthProvider \} from '@\/components\/AuthProvider';/g)?.length).toBe(1);
+    expect(secondLayout.match(/<AuthProvider>/g)?.length).toBe(1);
+    expect(secondLayout.match(/<\/AuthProvider>/g)?.length).toBe(1);
+
+    const envContent = fs.readFileSync('.env.local', 'utf-8');
+    expect(envContent.match(/NILE_DATABASE_URL=/g)?.length).toBe(1);
+    expect(fs.existsSync(path.join('src', 'app', 'api', 'auth', 'route.ts'))).toBe(true);
+    expect(fs.existsSync(path.join('src', 'components', 'AuthProvider.tsx'))).toBe(true);
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -11,6 +11,90 @@ import axios from 'axios';
 
 type GetOptions = () => GlobalOptions;
 
+function requireWorkspaceAndDatabase(configManager: ConfigManager): { workspaceSlug: string; databaseName: string } {
+  const workspaceSlug = configManager.getWorkspace();
+  if (!workspaceSlug) {
+    throw new Error('No workspace specified. Use one of:\n' +
+      '1. --workspace flag\n' +
+      '2. nile config --workspace <name>\n' +
+      '3. NILE_WORKSPACE environment variable');
+  }
+
+  const databaseName = configManager.getDatabase();
+  if (!databaseName) {
+    throw new Error('No database specified. Use one of:\n' +
+      '1. --db flag\n' +
+      '2. nile config --db <name>\n' +
+      '3. NILE_DB environment variable');
+  }
+
+  return { workspaceSlug, databaseName };
+}
+
+function buildEnvContent(envVars: Record<string, string>): string {
+  return Object.entries(envVars)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+}
+
+function upsertEnvFile(filePath: string, envVars: Record<string, string>): void {
+  const existingEntries = new Map<string, string>();
+
+  if (fs.existsSync(filePath)) {
+    const existingContent = fs.readFileSync(filePath, 'utf-8');
+    existingContent
+      .split(/\r?\n/)
+      .filter(line => line.trim().length > 0 && !line.trim().startsWith('#'))
+      .forEach(line => {
+        const separatorIndex = line.indexOf('=');
+        if (separatorIndex > 0) {
+          existingEntries.set(line.slice(0, separatorIndex), line.slice(separatorIndex + 1));
+        }
+      });
+  }
+
+  Object.entries(envVars).forEach(([key, value]) => {
+    existingEntries.set(key, value);
+  });
+
+  fs.writeFileSync(filePath, `${buildEnvContent(Object.fromEntries(existingEntries))}\n`);
+}
+
+function ensureAuthProviderImport(layoutContent: string): string {
+  if (layoutContent.includes("import { AuthProvider } from '@/components/AuthProvider';")) {
+    return layoutContent;
+  }
+
+  return layoutContent.replace(
+    'export default function RootLayout',
+    `import { AuthProvider } from '@/components/AuthProvider';\n\nexport default function RootLayout`
+  );
+}
+
+function wrapBodyWithAuthProvider(layoutContent: string): string {
+  if (layoutContent.includes('<AuthProvider>')) {
+    return layoutContent;
+  }
+
+  return layoutContent
+    .replace('<body>', '<body>\n      <AuthProvider>')
+    .replace('</body>', '      </AuthProvider>\n    </body>');
+}
+
+async function buildAuthEnvVars(configManager: ConfigManager, api: NileAPI): Promise<Record<string, string>> {
+  const { workspaceSlug, databaseName } = requireWorkspaceAndDatabase(configManager);
+  console.log(theme.dim('\nFetching database credentials...'));
+  const credentials = await api.createDatabaseCredentials(workspaceSlug, databaseName);
+  const connection = await api.getDatabaseConnection(workspaceSlug, databaseName);
+
+  return {
+    NILE_DATABASE_URL: `postgres://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`,
+    NILE_WORKSPACE: workspaceSlug,
+    NILE_API_KEY: credentials.id,
+    NILE_API_SECRET: credentials.password
+  };
+}
+
 export function createAuthCommand(getOptions: GetOptions): Command {
   const auth = new Command('auth')
     .description('Manage authentication')
@@ -30,14 +114,6 @@ ${getGlobalOptionsHelp()}`);
       try {
         const options = getOptions();
         const configManager = new ConfigManager(options);
-        const workspaceSlug = configManager.getWorkspace();
-        if (!workspaceSlug) {
-          throw new Error('No workspace specified. Use one of:\n' +
-            '1. --workspace flag\n' +
-            '2. nile config --workspace <name>\n' +
-            '3. NILE_WORKSPACE environment variable');
-        }
-
         const api = new NileAPI({
           token: configManager.getToken(),
           dbHost: configManager.getDbHost(),
@@ -58,25 +134,12 @@ ${getGlobalOptionsHelp()}`);
           console.log(theme.dim('\nInstalling required dependencies...'));
           execSync('npm install @niledatabase/react @niledatabase/server', { stdio: 'inherit' });
 
-          // Get database credentials
-          console.log(theme.dim('\nFetching database credentials...'));
-          const credentials = await api.createDatabaseCredentials(workspaceSlug, 'test');
-          const connection = await api.getDatabaseConnection(workspaceSlug, 'test');
-
           // Create environment variables
-          const envVars = {
-            NILE_DATABASE_URL: `postgres://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`,
-            NILE_WORKSPACE: workspaceSlug,
-            NILE_API_KEY: credentials.id,
-            NILE_API_SECRET: credentials.password
-          };
+          const envVars = await buildAuthEnvVars(configManager, api);
 
           // Write to .env.local
           console.log(theme.dim('\nWriting environment variables to .env.local...'));
-          const envContent = Object.entries(envVars)
-            .map(([key, value]) => `${key}=${value}`)
-            .join('\n');
-          fs.writeFileSync('.env.local', envContent);
+          upsertEnvFile('.env.local', envVars);
 
           // Create API routes
           console.log(theme.dim('\nCreating API routes...'));
@@ -144,17 +207,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           // Update root layout
           console.log(theme.dim('\nUpdating root layout...'));
           const layoutFile = path.join('src', 'app', 'layout.tsx');
+          if (!fs.existsSync(layoutFile)) {
+            throw new Error('Could not find src/app/layout.tsx. Please run this command from a Next.js app using the App Router.');
+          }
           const layoutContent = fs.readFileSync(layoutFile, 'utf-8');
-          const updatedLayout = layoutContent.replace(
-            'export default function RootLayout',
-            `import { AuthProvider } from '@/components/AuthProvider';\n\nexport default function RootLayout`
-          ).replace(
-            '<body>',
-            '<body>\n      <AuthProvider>'
-          ).replace(
-            '</body>',
-            '      </AuthProvider>\n    </body>'
-          );
+          const updatedLayout = wrapBodyWithAuthProvider(ensureAuthProviderImport(layoutContent));
           fs.writeFileSync(layoutFile, updatedLayout);
 
           console.log(theme.success('\nAuthentication setup complete!'));
@@ -180,33 +237,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       try {
         const options = getOptions();
         const configManager = new ConfigManager(options);
-        const workspaceSlug = configManager.getWorkspace();
-        if (!workspaceSlug) {
-          throw new Error('No workspace specified. Use one of:\n' +
-            '1. --workspace flag\n' +
-            '2. nile config --workspace <name>\n' +
-            '3. NILE_WORKSPACE environment variable');
-        }
-
         const api = new NileAPI({
           token: configManager.getToken(),
           dbHost: configManager.getDbHost(),
           controlPlaneUrl: configManager.getGlobalHost(),
           debug: options.debug
         });
-
-        // Get database credentials
-        console.log(theme.dim('\nFetching database credentials...'));
-        const credentials = await api.createDatabaseCredentials(workspaceSlug, 'test');
-        const connection = await api.getDatabaseConnection(workspaceSlug, 'test');
-
-        // Generate environment variables
-        const envVars = {
-          NILE_DATABASE_URL: `postgres://${connection.user}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`,
-          NILE_WORKSPACE: workspaceSlug,
-          NILE_API_KEY: credentials.id,
-          NILE_API_SECRET: credentials.password
-        };
+        const envVars = await buildAuthEnvVars(configManager, api);
 
         // Format environment variables
         const envContent = Object.entries(envVars)
@@ -216,7 +253,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // Output to file if specified
         if (cmdOptions.output) {
           console.log(theme.dim(`\nWriting environment variables to ${cmdOptions.output}...`));
-          fs.writeFileSync(cmdOptions.output, envContent);
+          upsertEnvFile(cmdOptions.output, envVars);
           console.log(theme.success(`\nEnvironment variables written to ${cmdOptions.output}`));
         } else {
           // Display in terminal


### PR DESCRIPTION
### Summary
This PR fixes nile auth quickstart --nextjs and nile auth env so they use the selected database from CLI config or --db instead of hardcoding test

### Problem
Previously, auth setup always requested credentials for the test database, even when a different database was selected. That could:

- ignore --db and saved config
- generate credentials for the wrong database
- fail for workspaces that do not have a database named test

### Changes
- added a shared helper to require both workspace and database for auth flows
- updated auth quickstart to generate env vars from the selected database
- updated auth env to generate env vars from the selected database
- changed env file writes to upsert Nile auth keys instead of replacing the whole file